### PR TITLE
FIX: More accurate matching for tag names

### DIFF
--- a/common/header.html
+++ b/common/header.html
@@ -27,7 +27,11 @@
     }
 
   	/// Add custom tag icon from theme settings
-  	let tagIconItem = tagIconList.find((str) => str.indexOf(tag) > -1);
+    let tagIconItem = tagIconList.find((str) =>
+      str.indexOf(",") > -1
+        ? tag.indexOf(str.substr(0, str.indexOf(","))) > -1
+        : ""
+    );
   	let tagIconHTML = '';
   	if (tagIconItem) {
   		let tagIcon = tagIconItem.split(',');


### PR DESCRIPTION
Previously, if you had the following tag -> icon mappings in the setting:

```
education-team,users
us,globe
```

The `us` tag would not work, because the returned match would be the
first row. This PR fixes it so matching only checks the tag names (i.e.
only the first column in the CSV-like data).