### PR TITLE
FIX: tag description on hover

### DIFF
--- a/javascripts/discourse/initializers/tag-icons.js.es6
+++ b/javascripts/discourse/initializers/tag-icons.js.es6
@@ -52,6 +52,7 @@ function iconTagRenderer(tag, params) {
     href +
     " data-tag-name=" +
     tag +
+    (params.description ? ' title="' + params.description + '" ' : "") +
     " class='" +
     classes.join(" ") +
     "'>" +


### PR DESCRIPTION
Solution is in core and this component should use it as well:

https://github.com/discourse/discourse/commit/9cabd3721b13a37c63464043dbae2d41dd908349#diff-f64eb8f03ac197dd71d469478344dbbb67943445e45133320234ad963f02de36R47