### PR TITLE
FEATURE: Use new experimental plugin API for sidebar

### DIFF
--- a/javascripts/discourse/initializers/tag-icons.js.es6
+++ b/javascripts/discourse/initializers/tag-icons.js.es6
@@ -73,8 +73,24 @@ export default {
   name: "tag-icons",
 
   initialize() {
-    withPluginApi("0.8.31", (api) => {
+    withPluginApi("1.6.0", (api) => {
       api.replaceTagRenderer(iconTagRenderer);
+
+      if (api.registerCustomTagSectionLinkPrefixIcon) {
+        const tagIconList = settings.tag_icon_list.split("|");
+
+        tagIconList.forEach((tagIcon) => {
+          const [tagName, prefixValue, prefixColor] = tagIcon.split(",");
+
+          if (tagName && prefixValue) {
+            api.registerCustomTagSectionLinkPrefixIcon({
+              tagName,
+              prefixValue,
+              prefixColor,
+            });
+          }
+        });
+      }
     });
   },
 };

--- a/test/acceptance/sidebar-tag-icons-test.js
+++ b/test/acceptance/sidebar-tag-icons-test.js
@@ -1,0 +1,56 @@
+import { test } from "qunit";
+import {
+  acceptance,
+  exists,
+  query,
+} from "discourse/tests/helpers/qunit-helpers";
+import { visit } from "@ember/test-helpers";
+
+acceptance("Sidebar - Tag icons", function (needs) {
+  needs.user({
+    display_sidebar_tags: true,
+    sidebar_tags: [
+      { name: "tag2", pm_only: false },
+      { name: "tag1", pm_only: false },
+      { name: "tag3", pm_only: false },
+    ],
+  });
+
+  needs.hooks.beforeEach(() => {
+    settings.tag_icon_list = `tag1,wrench,#FF0000|tag2,question-circle,#FFF`;
+  });
+
+  test("Icon for tag when `tag_icon_list` theme setting has been configured", async function (assert) {
+    await visit("/");
+
+    assert.ok(
+      exists(
+        `.sidebar-section-link[data-tag-name="tag1"] .prefix-icon.d-icon-wrench`
+      ),
+      "wrench icon is displayed for tag1 section link's prefix icon"
+    );
+
+    assert.strictEqual(
+      query(
+        `.sidebar-section-link[data-tag-name="tag1"] .sidebar-section-link-prefix`
+      ).style.color,
+      "rgb(255, 0, 0)",
+      `tag1 section link's prefix icon has the right color`
+    );
+
+    assert.ok(
+      exists(
+        `.sidebar-section-link[data-tag-name="tag2"] .prefix-icon.d-icon-question-circle`
+      ),
+      `question-circle icon is displayed for tag2 section link's prefix icon`
+    );
+
+    assert.strictEqual(
+      query(
+        `.sidebar-section-link[data-tag-name="tag2"] .sidebar-section-link-prefix`
+      ).style.color,
+      "rgb(255, 255, 255)",
+      `tag2 section link's prefix icon has the right color`
+    );
+  });
+});


### PR DESCRIPTION
What does this change do? 

This change uses the experimental `registerCustomTagSectionLinkPrefixIcon` plugin API
added to core to add support for custom icons for tag section links in Sidebar. Note
that the plugin APIs are marked as experimental because Discourse core
may soon support customizable tag icons so this theme component may
eventually become redundant.

Screenshots:

For the given settings: 

![Screenshot from 2023-05-22 14-35-36](https://github.com/discourse/discourse-tag-icons/assets/4335742/8d6905c1-80ba-4df2-b271-99362e607752)

Sidebar is rendered as:

![Screenshot from 2023-05-22 14-35-40](https://github.com/discourse/discourse-tag-icons/assets/4335742/7601fe59-717f-433c-8c95-8026e55af8e1)
