### PR TITLE
DEV: Sync latest changes from core

### DIFF
--- a/javascripts/discourse/initializers/tag-icons.js.es6
+++ b/javascripts/discourse/initializers/tag-icons.js.es6
@@ -1,5 +1,6 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { iconHTML } from "discourse-common/lib/icon-library";
+import escape from "discourse-common/lib/escape";
 import getURL from "discourse-common/lib/get-url";
 import Handlebars from "handlebars";
 import { helperContext } from "discourse-common/lib/helpers";
@@ -16,7 +17,7 @@ function iconTagRenderer(tag, params) {
   const tagName = params.tagName || "a";
   let path;
   if (tagName === "a" && !params.noHref) {
-    if (params.isPrivateMessage && currentUser) {
+    if ((params.isPrivateMessage || params.pmOnly) && currentUser) {
       const username = params.tagsForUser
         ? params.tagsForUser
         : currentUser.username;
@@ -33,6 +34,14 @@ function iconTagRenderer(tag, params) {
   if (params.extraClass) {
     classes.push(params.extraClass);
   }
+
+  if (params.size) {
+    classes.push(params.size);
+  }
+
+  // remove all html tags from hover text
+  const hoverDescription =
+    params.description && params.description.replace(/<.+?>/g, "");
 
   /// Add custom tag icon from theme settings
   let tagIconItem = tagIconList.find((str) => {
@@ -56,12 +65,12 @@ function iconTagRenderer(tag, params) {
     href +
     " data-tag-name=" +
     tag +
-    (params.description ? ' title="' + params.description + '" ' : "") +
+    (params.description ? ' title="' + escape(hoverDescription) + '" ' : "") +
     " class='" +
     classes.join(" ") +
     "'>" +
     tagIconHTML + // inject tag Icon in html
-    visibleName +
+    (params.displayName ? escape(params.displayName) : visibleName) +
     "</" +
     tagName +
     ">";

--- a/test/acceptance/tag-icons-test.js.es6
+++ b/test/acceptance/tag-icons-test.js.es6
@@ -8,6 +8,9 @@ acceptance("Topic with tags", function (needs) {
 
   const topicResponse = topicFixtures["/t/280/1.json"];
   topicResponse.tags = ["tag1", "newsman"];
+  topicResponse.tags_descriptions = {
+    newsman: "newsman <a href='test'>link</a>",
+  };
 
   test("Decorate topic title", async function (assert) {
     await visit("/t/internationalization-localization/280");
@@ -40,5 +43,13 @@ acceptance("Topic with tags", function (needs) {
 
     const el = queryAll(".discourse-tags a.discourse-tag .tag-icon .d-icon")[0];
     assert.ok(el.classList.contains("d-icon-cog"), "tag matches correct icon");
+
+    assert
+      .dom(".discourse-tag[data-tag-name='newsman']")
+      .hasAttribute(
+        "title",
+        "newsman link",
+        "it has correct title without markup"
+      );
   });
 });


### PR DESCRIPTION
Related core commits:
* [#21391](https://github.com/discourse/discourse/pull/21391) - [diff](https://github.com/discourse/discourse/pull/21391/files#diff-f64eb8f03ac197dd71d469478344dbbb67943445e45133320234ad963f02de36)
* [#22994](https://github.com/discourse/discourse/pull/22994) - [diff](https://github.com/discourse/discourse/pull/22994/files#diff-f64eb8f03ac197dd71d469478344dbbb67943445e45133320234ad963f02de36)
* [#23675](https://github.com/discourse/discourse/pull/23675) - [diff](https://github.com/discourse/discourse/pull/23675/files#diff-f64eb8f03ac197dd71d469478344dbbb67943445e45133320234ad963f02de36)
* [#23790](https://github.com/discourse/discourse/pull/23790) - [diff](https://github.com/discourse/discourse/pull/23790/files#diff-f64eb8f03ac197dd71d469478344dbbb67943445e45133320234ad963f02de36)

This syncs the latest changes from [`render-tag.js`](https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/lib/render-tag.js).
