### PR TITLE
FEATURE: display tags icon in post body

### DIFF
--- a/javascripts/discourse/initializers/tag-icons.js
+++ b/javascripts/discourse/initializers/tag-icons.js
@@ -135,7 +135,7 @@ export default {
         }
       });
 
-      if (settings.render_tag_icon_in_post && api.registerHashtagType) {
+      if (api.registerHashtagType) {
         api.registerHashtagType(
           "tag",
           new TagHashtagTypeWithIcon(tagsMap, owner)

--- a/javascripts/discourse/initializers/tag-icons.js
+++ b/javascripts/discourse/initializers/tag-icons.js
@@ -99,9 +99,7 @@ class TagHashtagTypeWithIcon extends TagHashtagType {
       }
       return newIcon.outerHTML;
     } else {
-      return iconHTML(hashtag.icon, {
-        class: `hashtag-color--${this.type}-${hashtag.id}`,
-      });
+      return super.generateIconHTML(hashtag);
     }
   }
 }

--- a/settings.yml
+++ b/settings.yml
@@ -2,9 +2,6 @@ tag_icon_list:
   default: "tag1,question-circle,#CC0000|"
   type: "list"
   description: 'Enter comma-delimited configuration for tags, in the format "tag-slug,icon,iconColor". Icon color is optional.'
-render_tag_icon_in_post:
-  default: true
-  description: "Show tag icons in the post body"
 svg_icons:
   default: "question-circle"
   type: "list"

--- a/settings.yml
+++ b/settings.yml
@@ -2,6 +2,9 @@ tag_icon_list:
   default: "tag1,question-circle,#CC0000|"
   type: "list"
   description: 'Enter comma-delimited configuration for tags, in the format "tag-slug,icon,iconColor". Icon color is optional.'
+render_tag_icon_in_post:
+  default: true
+  description: "Show tag icons in the post body"
 svg_icons:
   default: "question-circle"
   type: "list"

--- a/test/acceptance/post-body-tag-icons-test.js
+++ b/test/acceptance/post-body-tag-icons-test.js
@@ -1,0 +1,75 @@
+import { visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import TopicFixtures from "discourse/tests/fixtures/topic";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import { cloneJSON } from "discourse-common/lib/object";
+
+function makeHashtagHTML(tag) {
+  return `<a class=\"hashtag-cooked\" href=\"${tag.href}\" data-type=\"tag\" data-slug=\"${tag.slug}\" data-id=\"${tag.id}\"><span class=\"hashtag-icon-placeholder\"><svg class=\"fa d-icon d-icon-square-full svg-icon svg-node\"><use href=\"#square-full\"></use></svg></span><span>${tag.name}</span></a>`;
+}
+
+acceptance("Post body - Tag icons", function (needs) {
+  needs.user();
+
+  const tags = [
+    {
+      id: 1,
+      name: "Test-1",
+      slug: "test-1",
+      color: "111111",
+    },
+    {
+      id: 2,
+      name: "Test-2",
+      slug: "test-2",
+      color: "000000",
+    },
+    {
+      id: 3,
+      name: "Test-3",
+      slug: "test-3",
+      color: "888888",
+    },
+  ];
+
+  needs.hooks.beforeEach(function () {
+    settings.tag_icon_list = `test-1,wrench,#FF0000|test-2,question-circle`;
+  });
+
+  needs.pretender((server, helper) => {
+    server.get("/t/131.json", () => {
+      const topicList = cloneJSON(TopicFixtures["/t/130.json"]);
+      topicList.post_stream.posts[0].cooked = `<p>${makeHashtagHTML(
+        tags[0]
+      )} ${makeHashtagHTML(tags[1])} ${makeHashtagHTML(tags[2])}</p>`;
+      return helper.response(topicList);
+    });
+  });
+
+  test("Icon for tag when `tag_icon_list` theme setting has been configured", async function (assert) {
+    await visit("/t/131");
+
+    assert
+      .dom(
+        `.cooked .hashtag-cooked[data-id="1"] .hashtag-tag-icon .d-icon-wrench`
+      )
+      .exists("wrench icon is displayed for tag-1");
+
+    assert
+      .dom(`.cooked .hashtag-cooked[data-id="1"] .hashtag-tag-icon`)
+      .hasStyle(
+        { color: "rgb(255, 0, 0)" },
+        "tag-1 's icon has the right color"
+      );
+
+    assert
+      .dom(
+        `.cooked .hashtag-cooked[data-id="2"] .hashtag-tag-icon .d-icon-question-circle`
+      )
+      .exists("question-circle icon is displayed for tag-2");
+
+    assert
+      .dom(`.cooked .hashtag-cooked[data-id="3"] svg.d-icon-tag`)
+      .exists("unconfigured tags have a default badge");
+  });
+});


### PR DESCRIPTION
This commit allows displaying tags icon in the body of the post.

## Screenshots

New setting:

![image](https://github.com/user-attachments/assets/a5617687-a550-43d9-a873-34007d769ca8)

Before change:

![image](https://github.com/user-attachments/assets/5d81b367-bfd0-45b8-b1db-ba583d3cb3d0)


After change:

![image](https://github.com/user-attachments/assets/bb7e1d3b-f4bc-4128-b076-b02d403b6cfe)


Related meta topic: https://meta.discourse.org/t/tag-icons-dont-show-up-in-post-text/315852