### PR TITLE
DEV: Migrate settings defaults from deprecated icon names

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -1,7 +1,7 @@
 tag_icon_list:
-  default: "tag1,question-circle,#CC0000|"
+  default: "tag1,circle-question,#CC0000|"
   type: "list"
 svg_icons:
-  default: "question-circle"
+  default: "circle-question"
   type: "list"
   list_type: "compact"


### PR DESCRIPTION
This PR migrates deprecated Font Awesome icon names saved in settings as defaults. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.