### PR TITLE
DEV: Remove `console.warn`

### DIFF
--- a/javascripts/discourse/lib/colors.js
+++ b/javascripts/discourse/lib/colors.js
@@ -13,8 +13,6 @@ const hexToRgb = (hex) => {
   }
 
   if (!/^[0-9a-fA-F]{6}$/.test(value)) {
-    // eslint-disable-next-line no-console
-    console.warn(`Invalid hex color: ${hex}`);
     return false;
   }
 


### PR DESCRIPTION
provided no value, polluted test output