### PR TITLE
DEV: Match tag icons on the name the viewer reads

### DIFF
--- a/spec/system/page_objects/components/tag_icon.rb
+++ b/spec/system/page_objects/components/tag_icon.rb
@@ -3,16 +3,18 @@
 module PageObjects
   module Components
     class TagIcon < PageObjects::Components::Base
+      # Tags are matched on the name the viewer reads, so these assertions hold
+      # whether or not a localization applies.
       def has_icon_for_tag?(tag_name:, icon:, color: nil)
-        selector = ".discourse-tag[data-tag-name='#{tag_name}']"
+        selector = ".discourse-tag"
         selector += "[style*='--color1: #{color}; --color2: #fffd;']" if color
-        selector += " .tag-icon .d-icon-#{icon}"
-        page.has_css?(selector)
+
+        page.has_css?("#{selector}:has(.tag-icon .d-icon-#{icon})", text: tag_name)
       end
 
       def has_no_icon_for_tag?(tag_name:)
-        page.has_css?(".discourse-tag[data-tag-name='#{tag_name}']") &&
-          page.has_no_css?(".discourse-tag[data-tag-name='#{tag_name}'] .tag-icon")
+        page.has_css?(".discourse-tag", text: tag_name) &&
+          page.has_no_css?(".discourse-tag:has(.tag-icon)", text: tag_name)
       end
     end
   end


### PR DESCRIPTION
The `TagIcon` page object located tags through `.discourse-tag[data-tag-name=...]`. [discourse/discourse#42869](https://github.com/discourse/discourse/pull/42869) changes that attribute to carry the tag's untranslated name so it stays stable across locales, which breaks the localized specs here — they pass `サポート`, and the attribute will read `support`.

The icon itself renders correctly either way; only the locator was stale. Matching on the visible text plus `:has(.tag-icon ...)` asserts what the reader actually sees and is independent of which name the attribute carries.

Verified green against core `main` and against the core PR branch, so this can merge in either order.